### PR TITLE
add dependent category example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
+/bin/
 output
 composer.phar

--- a/doc/define-mandatory-properties.md
+++ b/doc/define-mandatory-properties.md
@@ -30,6 +30,7 @@ public static function mandatory()
 ```php
 use Sensorario\Resources\Configurator;
 use Sensorario\Resources\Container;
+use Sensorario\Resources\Resource;
 
 $configurator = new Configurator(
   'foo',

--- a/doc/macrocategory-category-subcategory.md
+++ b/doc/macrocategory-category-subcategory.md
@@ -1,0 +1,77 @@
+# Macrocategory Category Subcategory example
+
+In this example we consider three allowed values:
+
+ - macro category
+ - category
+ - subcatetory
+
+```php
+<?php
+
+require './vendor/autoload.php';
+
+use Sensorario\Resources\Configurator;
+use Sensorario\Resources\Container;
+use Sensorario\Resources\Resource;
+
+$configurator = new Configurator(
+    'mt-distribution',
+    new Container([
+        'resources' => [
+            'mt-distribution' => [
+                'constraints' => [
+                    'allowed' => [
+                        'macrocategory',
+                        'category',
+                        'subcategory',
+                    ],
+                    'mandatory' => [
+                        'macrocategory' => [
+                            'when' => [
+                                'property' => 'category',
+                                'condition' => 'is_present',
+                            ]
+                        ],
+                        'category' => [
+                            'when' => [
+                                'property' => 'subcategory',
+                                'condition' => 'is_present',
+                            ]
+                        ],
+                    ],
+                ]
+            ],
+        ],
+    ])
+);
+```
+
+The third one requires second. The second requires first. A request initialized with these values will throw an exception because are not present values category and macrocategory.
+
+```php
+$properties = [
+    'subcategory' => 'beer',
+];
+
+Resource::box(
+    $properties,
+    $configurator
+);
+```
+
+This request, instead, is valid.
+
+```php
+
+$properties = [
+    'macrocategory' => 'beer',
+    'category' => 'beer',
+    'subcategory' => 'beer',
+];
+
+Resource::box(
+    $properties,
+    $configurator
+);
+```

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,7 @@
  - [Default values][2]
  - [Example][10]
  - [Global configuration][12]
+ - [Mandatory conditional example][16]
  - [Mandatory properties][5]
  - [Overridable values][11]
  - [Property type][6]
@@ -40,3 +41,4 @@
  [13]: doc/ranges.md
  [14]: doc/raw-example.md
  [15]: doc/symfony-example.md
+ [16]: doc/macrocategory-category-subcategory.md

--- a/src/Sensorario/Resources/Validators/Validators/MandatoryProperty.php
+++ b/src/Sensorario/Resources/Validators/Validators/MandatoryProperty.php
@@ -18,12 +18,17 @@ final class MandatoryProperty implements Validator
 {
     public function check(Resource $resource)
     {
-        foreach ($resource->mandatory() as $key => $value) {
+        foreach ($resource->mandatory() as $mandatoryProperty => $value) {
             if (isset($value['when']['condition'])) {
-                throw new \Sensorario\Resources\Exceptions\PropertyNotSetException(
-                    "Property `" . get_class($resource)
-                    . "::\${$key}` is mandatory but not set"
-                );
+                $when = $value['when'];
+                if ('is_present' == $when['condition']) {
+                    if (!$resource->hasProperty($mandatoryProperty)) {
+                        throw new \Sensorario\Resources\Exceptions\PropertyNotSetException(
+                            "Property `" . get_class($resource)
+                            . "::\${$mandatoryProperty}` is mandatory but not set"
+                        );
+                    }
+                }
             }
         }
     }

--- a/tests/Resources/MandatoryDependency.php
+++ b/tests/Resources/MandatoryDependency.php
@@ -17,7 +17,7 @@ final class MandatoryDependency extends Resource
 {
     const FOO             = 'foo';
     const MELLO           = 'mello';
-    const MANDATORY_MELLO = 'mandatory_mello';
+    const MANDATORY_MELLO = 'makes_mello_mandatory';
 
     public function mandatory()
     {
@@ -25,7 +25,7 @@ final class MandatoryDependency extends Resource
             MandatoryDependency::FOO,
             MandatoryDependency::MELLO => [
                 'when' => [
-                    'property' => 'mandatory_mello',
+                    'property' => 'makes_mello_mandatory',
                     'condition' => 'is_present',
                 ]
             ],

--- a/tests/Sensorario/Resources/ResourceTest.php
+++ b/tests/Sensorario/Resources/ResourceTest.php
@@ -329,7 +329,7 @@ final class ResourceTest extends TestCase
     {
         MandatoryDependency::box([
             'foo' => 'bar',
-            'mandatory_mello' => 'bar',
+            'makes_mello_mandatory' => 'bar',
         ]);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Add documentation for mandatory continionals validator. This example cover the case of a tree of dependencies like:

 - macrocategory
   - category
     - subcategory
